### PR TITLE
Add null safety check in DatasetController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nbactions.xml
 *.swo
 nbactions.xml
 
+.vscode/

--- a/rest/src/main/java/org/n52/web/ctrl/DatasetController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/DatasetController.java
@@ -68,6 +68,9 @@ public class DatasetController extends AbstractDatasetController {
 
     @Override
     protected Long getSize(IoParameters parameters) {
+        if (parameters == null) {
+            return 0L;
+        }
         return getEntityCounter().getDatasetCount(parameters);
     }
 


### PR DESCRIPTION
This PR adds a simple null safety check when calculating the dataset size
to prevent potential NullPointerExceptions.

No functional behavior is changed for valid requests.
